### PR TITLE
Ensure proper mount ordering for qbittorrent service

### DIFF
--- a/roles/media/qbittorrent.nix
+++ b/roles/media/qbittorrent.nix
@@ -40,6 +40,12 @@
     openFirewall = true;
   };
 
+  # Ensure qbittorrent starts only after /srv/media is mounted
+  systemd.services.qbittorrent = {
+    after = [ "srv-media.mount" ];
+    requires = [ "srv-media.mount" ];
+  };
+
   systemd.services.qui = {
     wantedBy = [ "multi-user.target" ];
     after = [ "network-online.target" ];


### PR DESCRIPTION
Add systemd dependencies to ensure qbittorrent starts only after
/srv/media is mounted. This prevents the service from starting before
its required storage is available.

The dependency chain is now:
- /mnt (on mars) → /srv/media → qbittorrent.service

The /srv/media → /mnt dependency was already configured in
common/media.nix via the depends option.

https://claude.ai/code/session_01K6q4AdaZbL8aCdxL8X1CZj